### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/node_modules/fsevents/node_modules/jsbn/example.html
+++ b/node_modules/fsevents/node_modules/jsbn/example.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">
+        <meta charset="utf-8"/>
         <title></title>
     </head>
     <body>

--- a/node_modules/fsevents/node_modules/node-pre-gyp/lib/util/nw-pre-gyp/index.html
+++ b/node_modules/fsevents/node_modules/node-pre-gyp/lib/util/nw-pre-gyp/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<meta charset="utf-8">
+<meta charset="utf-8"/>
 <title>Node-webkit-based module test</title>
 <script>
 function nwModuleTest(){

--- a/node_modules/nodemon/web/index.html
+++ b/node_modules/nodemon/web/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset=utf-8>
-<meta name="viewport" content="width=device-width">
+<meta charset=utf-8/>
+<meta name="viewport" content="width=device-width"/>
 <title>nodemon</title>
 <style id="jsbin-css">
 @font-face {


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tag anyhow - that is not an excuse for not writing specification valid code, and I am more than happy to help correct this. In the spirit of an open-source community! The changes in this PullRequest will not break your code in any way.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
